### PR TITLE
Fix badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
   <img src="docs/source/_static/images/banner.gif" alt="task dropdown" width="640">
 </p>
 
-![Python](https://img.shields.io/badge/Python-3.10|3.11|3.12|3.13-blue?logo=python&logoColor=white)
-[![Test Status](https://github.com/bdaiinstitute/judo/actions/workflows/test.yml/badge.svg)](https://github.com/bdaiinstitute/judo)
+[![Python](https://img.shields.io/badge/Python-3.10|3.11|3.12|3.13-blue?logo=python&logoColor=white)](https://github.com/bdaiinstitute/judo)
 &nbsp;
-[![Docs Status](https://github.com/bdaiinstitute/judo/actions/workflows/docs.yml/badge.svg)](https://github.com/bdaiinstitute/judo)
+[![Test Status](https://github.com/bdaiinstitute/judo/actions/workflows/test.yml/badge.svg)](https://github.com/bdaiinstitute/judo/actions/workflows/test.yml)
 &nbsp;
-[![Coverage Status](https://codecov.io/gh/bdaiinstitute/judo/graph/badge.svg?token=3GGYCZM2Y2)](https://github.com/bdaiinstitute/judo)
+[![Docs Status](https://github.com/bdaiinstitute/judo/actions/workflows/docs.yml/badge.svg)](https://github.com/bdaiinstitute/judo/actions/workflows/docs.yml)
+&nbsp;
+[![Coverage Status](https://codecov.io/gh/bdaiinstitute/judo/graph/badge.svg?token=3GGYCZM2Y2)](https://codecov.io/gh/bdaiinstitute/judo)
 
 
 `judo` is a `python` package inspired by [`mujoco_mpc`](https://github.com/google-deepmind/mujoco_mpc) that makes sampling-based MPC easy. Features include:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -33,15 +33,19 @@
 .. |python| image:: https://img.shields.io/badge/Python-3.10%7C3.11%7C3.12%7C3.13-blue?logo=python&logoColor=white
    :alt: Supported Python versions
    :target: https://github.com/bdaiinstitute/judo
+
 .. |test| image:: https://github.com/bdaiinstitute/judo/actions/workflows/test.yml/badge.svg
    :alt: Test status
-   :target: https://github.com/bdaiinstitute/judo
+   :target: https://github.com/bdaiinstitute/judo/actions/workflows/test.yml
+
 .. |docs| image:: https://github.com/bdaiinstitute/judo/actions/workflows/docs.yml/badge.svg
    :alt: Docs status
-   :target: https://github.com/bdaiinstitute/judo
+   :target: https://github.com/bdaiinstitute/judo/actions/workflows/docs.yml
+
 .. |coverage| image:: https://codecov.io/gh/bdaiinstitute/judo/graph/badge.svg?token=3GGYCZM2Y2
    :alt: Test coverage
-   :target: https://github.com/bdaiinstitute/judo
+   :target: https://codecov.io/gh/bdaiinstitute/judo
+
 .. |nbsp| unicode:: 0xA0
    :trim:
 


### PR DESCRIPTION
Points the badges on the README/docs to the following locations:
* python: repo
* tests: test workflow
* docs: docs workflow
* cov: coverage report