### PR TITLE
Update `nominal_knots` when `controller.max_opt_iters > 1`

### DIFF
--- a/judo/controller/controller.py
+++ b/judo/controller/controller.py
@@ -172,9 +172,10 @@ class Controller:
                 self.system_metadata,
             )
             i += 1
+            nominal_knots = self.optimizer.update_nominal_knots(self.candidate_knots, self.rewards)
 
         # Update nominal controls and spline.
-        self.nominal_knots = self.optimizer.update_nominal_knots(self.candidate_knots, self.rewards)
+        self.nominal_knots = nominal_knots
         self.times = new_times
         self.update_spline(self.times, self.nominal_knots)
         self.update_traces()


### PR DESCRIPTION
Slightly changed behavior for when `controller.max_opt_iters > 1`. Not sure if I fully understand the intended behavior so let me know if I'm missing something. Closes #13.

Credit to @lujieyang for pointing this out.