### PR TITLE
Fix typo in Brandon's last name

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you use `judo` in your research, please use the following citation:
 ```
 @inproceedings{li2025_judo,
   title     = {Judo: A User-Friendly Open-Source Package for Sampling-Based Model Predictive Control},
-  author    = {Albert Li and Simon Le Cleac'h and Brandon Huang and Aaron D. Ames and Jiuguang Wang and Preston Culbertson},
+  author    = {Albert Li and Simon Le Cleac'h and Brandon Hung and Aaron D. Ames and Jiuguang Wang and Preston Culbertson},
   booktitle = {Proceedings of the Workshop on Fast Motion Planning and Control in the Era of Parallelism at Robotics: Science and Systems (RSS)},
   year      = {2025},
   url       = {https://github.com/bdaiinstitute/judo},


### PR DESCRIPTION
Fixes a typo in @bhung-bdai's name in the README. Closes #12. 