### PR TITLE
Fix `nominal_knots` shape

### DIFF
--- a/judo/controller/controller.py
+++ b/judo/controller/controller.py
@@ -139,7 +139,7 @@ class Controller:
         i = 0
         while i < self.max_opt_iters and not self.optimizer.stop_cond():
             # sample controls and clamp to action bounds
-            self.candidate_knots = self.optimizer.sample_control_knots(nominal_knots[None])
+            self.candidate_knots = self.optimizer.sample_control_knots(nominal_knots)
             self.candidate_knots = np.clip(
                 self.candidate_knots,
                 self.task.actuator_ctrlrange[:, 0],

--- a/judo/controller/controller.py
+++ b/judo/controller/controller.py
@@ -125,7 +125,7 @@ class Controller:
 
         # Adjust time + move policy forward.
         new_times = curr_time + self.spline_timesteps
-        nominal_knots = self.spline(new_times)[None]
+        nominal_knots = self.spline(new_times)
 
         # resizing any variables due to changes in the GUI
         if len(self.model_data_pairs) != self.optimizer_cfg.num_rollouts:
@@ -139,7 +139,7 @@ class Controller:
         i = 0
         while i < self.max_opt_iters and not self.optimizer.stop_cond():
             # sample controls and clamp to action bounds
-            self.candidate_knots = self.optimizer.sample_control_knots(nominal_knots)
+            self.candidate_knots = self.optimizer.sample_control_knots(nominal_knots[None])
             self.candidate_knots = np.clip(
                 self.candidate_knots,
                 self.task.actuator_ctrlrange[:, 0],

--- a/judo/optimizers/cem.py
+++ b/judo/optimizers/cem.py
@@ -71,7 +71,7 @@ class CrossEntropyMethod(Optimizer[CrossEntropyMethodConfig]):
             ramp = np.linspace(noise_ramp / num_nodes, noise_ramp, num_nodes, endpoint=True)[:, None]
             self.sigma = np.clip(self.sigma * ramp, self.sigma_min, self.sigma_max)
         noised_knots = nominal_knots + self.sigma[None] * np.random.randn(num_rollouts - 1, num_nodes, self.nu)
-        return np.concatenate([nominal_knots, noised_knots])
+        return np.concatenate([nominal_knots[None], noised_knots])
 
     def update_nominal_knots(self, sampled_knots: np.ndarray, rewards: np.ndarray) -> np.ndarray:
         """Update the nominal control knots based on the sampled controls and rewards.

--- a/judo/optimizers/mppi.py
+++ b/judo/optimizers/mppi.py
@@ -56,7 +56,7 @@ class MPPI(Optimizer[MPPIConfig]):
         else:
             sigma = _sigma
         noised_knots = nominal_knots + sigma * np.random.randn(num_rollouts - 1, num_nodes, self.nu)
-        return np.concatenate([nominal_knots, noised_knots])
+        return np.concatenate([nominal_knots[None], noised_knots])
 
     def update_nominal_knots(self, sampled_knots: np.ndarray, rewards: np.ndarray) -> np.ndarray:
         """Update the nominal control knots based on the sampled controls and rewards.

--- a/judo/optimizers/ps.py
+++ b/judo/optimizers/ps.py
@@ -47,7 +47,7 @@ class PredictiveSampling(Optimizer[PredictiveSamplingConfig]):
         else:
             sigma = _sigma
         noised_knots = nominal_knots + sigma * np.random.randn(num_rollouts - 1, num_nodes, self.nu)
-        return np.concatenate([nominal_knots, noised_knots])
+        return np.concatenate([nominal_knots[None], noised_knots])
 
     def update_nominal_knots(self, sampled_knots: np.ndarray, rewards: np.ndarray) -> np.ndarray:
         """Update the nominal control knots based on the sampled controls and rewards.

--- a/tests/test_controller/test_controller.py
+++ b/tests/test_controller/test_controller.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC. All rights reserved.
+
+import numpy as np
+
+from judo.controller import Controller, ControllerConfig
+from judo.optimizers import Optimizer, OptimizerConfig, get_registered_optimizers
+from judo.tasks import CylinderPush, CylinderPushConfig
+
+# ##### #
+# TESTS #
+# ##### #
+
+
+def test_update_action() -> None:
+    """Tests the update_action method with different optimizers."""
+
+    def _setup_controller(opt_cls: type[Optimizer], opt_cfg: OptimizerConfig) -> Controller:
+        """Helper function to set up the controller."""
+        task = CylinderPush()
+        task_config = CylinderPushConfig()
+        opt = opt_cls(opt_cfg, task.nu)
+        controller = Controller(
+            ControllerConfig(max_opt_iters=2),
+            task,
+            task_config,
+            opt,
+            opt_cfg,
+            rollout_backend="mujoco",
+        )
+        return controller
+
+    # test with all registered optimizers
+    for _opt_name, (opt_cls, opt_cfg) in get_registered_optimizers().items():
+        controller = _setup_controller(opt_cls, opt_cfg)
+        curr_state = np.random.rand(controller.task.model.nq + controller.task.model.nv)
+        curr_time = 0.0
+
+        # check that update_action runs without error
+        controller.update_action(curr_state, curr_time)
+
+        # check that the nominal knots have the correct shape
+        assert controller.nominal_knots.shape == (controller.optimizer.num_nodes, controller.optimizer.nu)
+
+        # check that the candidate knots have the correct shape
+        assert controller.candidate_knots.shape == (
+            controller.optimizer.num_rollouts,
+            controller.optimizer.num_nodes,
+            controller.optimizer.nu,
+        )


### PR DESCRIPTION
Fix bad `nominal_knots` shape when `max_opt_iters > 1`.

**Bug**:
In the optimization loop of the controller, `self.optimizer.sample_control_knots()` takes `nominal_knots` of shape `(1, num_knots, nu)`, while `judo/controller/controller.py#L175` updates the `nominal_knots` to have shape `(num_knots, nu)`.

**Fix**:
Let `nominal_knots` always carry `(num_knots, nu)`, but pass `nominal_knots[None]` to `self.optimizer.sample_control_knots()`.