### PR TITLE
Improve visualizer aesthetics

### DIFF
--- a/judo/app/visualization.py
+++ b/judo/app/visualization.py
@@ -112,7 +112,7 @@ class VisualizationNode(DoraNode):
         self.data = mujoco.MjData(self.task.model)
         self.viser_model = ViserMjModel(
             self.server,
-            self.task.model,
+            self.task.spec,
             geom_exclude_substring=self.geom_exclude_substring,
         )
 

--- a/judo/models/xml/caltech_leap_components/params_and_default.xml
+++ b/judo/models/xml/caltech_leap_components/params_and_default.xml
@@ -1,5 +1,5 @@
 <mujoco model="leap_cube_default">
-  <compiler angle="radian" meshdir="./meshes/" />
+  <compiler angle="radian" />
   <option
     timestep="0.01"
     integrator="implicitfast"

--- a/judo/models/xml/caltech_leap_components/params_and_default_sim.xml
+++ b/judo/models/xml/caltech_leap_components/params_and_default_sim.xml
@@ -1,5 +1,5 @@
 <mujoco model="leap_cube_default">
-  <compiler angle="radian" meshdir="./meshes/" />
+  <compiler angle="radian" />
   <option
     timestep="0.002"
     integrator="implicitfast"

--- a/judo/models/xml/fr3_components/params_and_default.xml
+++ b/judo/models/xml/fr3_components/params_and_default.xml
@@ -1,5 +1,5 @@
 <mujoco model="fr3_default">
-  <compiler angle="radian" meshdir="assets"/>
+  <compiler angle="radian"/>
   <option integrator="implicitfast" timestep="0.004" impratio="10.0"/>
 
   <default>

--- a/judo/tasks/base.py
+++ b/judo/tasks/base.py
@@ -7,7 +7,7 @@ from typing import Any, Generic, TypeVar
 
 import mujoco
 import numpy as np
-from mujoco import MjData, MjModel
+from mujoco import MjData, MjModel, MjSpec
 
 
 @dataclass
@@ -25,7 +25,8 @@ class Task(ABC, Generic[ConfigT]):
         """Initialize the Mujoco task."""
         if not model_path:
             raise ValueError("Model path must be provided.")
-        self.model = MjModel.from_xml_path(str(model_path))
+        self.spec = MjSpec.from_file(str(model_path))
+        self.model = self.spec.compile()
         self.data = MjData(self.model)
         self.model_path = model_path
         self.sim_model = self.model if sim_model_path is None else MjModel.from_xml_path(str(sim_model_path))

--- a/judo/visualizers/model.py
+++ b/judo/visualizers/model.py
@@ -64,7 +64,6 @@ class ViserMjModel:
         for body in self._spec.bodies[1:]:
             # Sharp edge: not using the tree structure of the kinematics ...
             body_name = f"{body.name}"
-            print(f"Body name: {body_name}")
             self._bodies.append(self._target.scene.add_frame(body_name, show_axes=False))
 
             for geom in body.geoms:
@@ -75,7 +74,6 @@ class ViserMjModel:
                 geom_name = f"{body_name}/geom_{suffix}"
                 if geom_exclude_substring in geom_name:
                     continue
-                print(f"adding geom: {geom_name}")
                 self.add_geom(geom_name, geom)
 
         # Add traces
@@ -85,8 +83,6 @@ class ViserMjModel:
 
     def add_geom(self, geom_name: str, geom: Any) -> None:
         """Helper function for adding geoms to scene tree."""
-        # DEBUG
-        print(f"adding geom: {geom_name}")
         match geom.type:
             case mujoco.mjtGeom.mjGEOM_PLANE:
                 # TODO(pculbert): support more color options.
@@ -402,6 +398,7 @@ def add_mesh_from_file(
     if not mesh_file.exists():
         raise FileNotFoundError(f"Mesh file {mesh_file} does not exist.")
     mesh = trimesh.load(mesh_file, force="mesh")
+    breakpoint()
     assert isinstance(mesh, trimesh.Trimesh), "Loaded geometry is not a mesh type."
     if mesh_scale is not None:
         mesh.apply_scale(mesh_scale)

--- a/judo/visualizers/model.py
+++ b/judo/visualizers/model.py
@@ -19,7 +19,13 @@ from viser import (
     ViserServer,
 )
 
-from judo.visualizers.utils import apply_mujoco_material, count_trace_sensors, get_mesh_file, get_mesh_scale
+from judo.visualizers.utils import (
+    apply_mujoco_material,
+    count_trace_sensors,
+    get_mesh_file,
+    get_mesh_scale,
+    rgba_float_to_int,
+)
 
 DEFAULT_GRID_SECTION_COLOR = (0.02, 0.14, 0.44)
 DEFAULT_GRID_CELL_COLOR = (0.27, 0.55, 1)
@@ -471,16 +477,6 @@ def add_segments(
         visible: whether or not the lines are initially visible
     """
     return target.scene.add_line_segments(name, points, rgb, line_width, quat, pos, visible)
-
-
-def rgba_float_to_int(rgba_float: np.ndarray) -> np.ndarray:
-    """Convert RGBA float values in [0, 1] to int values in [0, 255]."""
-    return (255 * rgba_float).astype("int")
-
-
-def rgba_int_to_float(rgba_int: np.ndarray) -> np.ndarray:
-    """Convert RGBA int values in [0, 255] to float values in [0, 1]."""
-    return rgba_int / 255.0
 
 
 def set_mesh_color(mesh: trimesh.Trimesh, rgba: np.ndarray) -> None:

--- a/judo/visualizers/model.py
+++ b/judo/visualizers/model.py
@@ -76,7 +76,6 @@ class ViserMjModel:
                 _body_placeholder_idx += 1
             self._bodies.append(self._target.scene.add_frame(body_name, show_axes=False))
 
-
             for geom in body.geoms:
                 suffix = geom.name
                 if not suffix:  # if geom has no name, use a placeholder.

--- a/judo/visualizers/utils.py
+++ b/judo/visualizers/utils.py
@@ -5,7 +5,11 @@ from typing import List
 
 import mujoco
 import numpy as np
-from mujoco import MjModel, MjsGeom, MjSpec
+import trimesh
+from mujoco import MjModel, MjsGeom, MjsMaterial, MjSpec
+from PIL import Image
+from trimesh.visual import ColorVisuals, TextureVisuals
+from trimesh.visual.material import PBRMaterial
 
 
 def get_sensor_name(model: MjModel, sensorid: int) -> str:
@@ -60,6 +64,80 @@ def get_mesh_scale(spec: MjSpec, geom: MjsGeom) -> np.ndarray:
     mesh = spec.mesh(meshname)
 
     return mesh.scale
+
+
+def apply_mujoco_material(
+    mesh: trimesh.Trimesh,
+    material: MjsMaterial,
+    texture_dir: Path = Path("."),
+) -> None:
+    """
+    Applies a MuJoCo material specification to a trimesh mesh.
+
+    This function translates material properties, including color, PBR values,
+    and textures, into a trimesh-compatible visual format.
+
+    Args:
+        mesh: The trimesh.Trimesh object to modify.
+        material: An object with attributes matching the mjsMaterial struct.
+        texture_dir: The directory where texture files are located.
+    """
+
+    # Helper to convert float RGBA (0-1) to int RGBA (0-255)
+    def rgba_float_to_int(rgba_f: np.ndarray) -> np.ndarray:
+        return (np.array(rgba_f) * 255).astype(np.uint8)
+
+    # --- 1. Create and configure the PBR material ---
+    pbr_material = PBRMaterial()
+
+    # Get RGBA and ensure it's in the integer format trimesh expects
+    rgba = np.array(material.rgba)
+    if np.issubdtype(rgba.dtype, np.floating):
+        rgba = rgba_float_to_int(rgba)
+
+    # Set base color and alpha mode (preserving logic from your original function)
+    pbr_material.baseColorFactor = rgba
+    pbr_material.alphaMode = "BLEND" if rgba[-1] < 255 else "OPAQUE"
+
+    # Map PBR properties
+    pbr_material.metallicFactor = material.metallic
+    pbr_material.roughnessFactor = material.roughness
+    pbr_material.emissiveFactor = np.array([material.emission] * 3)
+
+    # Fallback for legacy shininess value if roughness is not set
+    if material.roughness == 0.0 and hasattr(material, "shininess") and material.shininess > 0:
+        pbr_material.roughnessFactor = np.sqrt(2.0 / (material.shininess + 2.0))
+
+    # --- 2. Handle Textured vs. Simple Color cases ---
+    has_texture = hasattr(material, "textures") and material.textures and material.textures[0]
+    texture_loaded = False
+
+    if has_texture:
+        texture_path = texture_dir / material.textures[0]
+        try:
+            texture_image = Image.open(texture_path)
+            pbr_material.baseColorTexture = texture_image
+
+            # For a texture to be applied, the mesh needs UV coordinates.
+            # We create a TextureVisuals object and assign the material.
+            mesh.visual = TextureVisuals(material=pbr_material)
+
+            # Handle texture repetition by scaling the UVs
+            if hasattr(material, "texrepeat") and hasattr(mesh.visual, "uv") and mesh.visual.uv is not None:
+                mesh.visual.uv *= material.texrepeat
+
+            texture_loaded = True
+        except FileNotFoundError:
+            print(f"Warning: Texture not found at '{texture_path}'. Falling back to simple color.")
+        except Exception as e:
+            print(f"Warning: Failed to load texture. Error: {e}. Falling back to simple color.")
+
+    # If no texture was specified or if it failed to load, apply a simple color
+    if not texture_loaded:
+        # For simple colors, ColorVisuals is the correct type.
+        # It sets a color for each face or vertex.
+        mesh.visual = ColorVisuals()
+        mesh.visual.face_colors = rgba
 
 
 def is_trace_sensor(model: MjModel, sensorid: int) -> bool:

--- a/judo/visualizers/utils.py
+++ b/judo/visualizers/utils.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2025 Robotics and AI Institute LLC. All rights reserved.
 
+from pathlib import Path
 from typing import List
 
 import mujoco
 import numpy as np
-from mujoco import MjModel
+from mujoco import MjModel, MjsGeom, MjSpec
 
 
 def get_sensor_name(model: MjModel, sensorid: int) -> str:
@@ -36,6 +37,29 @@ def get_mesh_data(model: MjModel, meshid: int) -> tuple[np.ndarray, np.ndarray]:
     facenum = model.mesh_facenum[meshid]
     faces = model.mesh_face[faceadr : faceadr + facenum]
     return vertices, faces
+
+
+def get_mesh_file(spec: MjSpec, geom: MjsGeom) -> Path:
+    """Extracts the mesh filepath for a particular geom from an MjSpec."""
+    assert geom.type == mujoco.mjtGeom.mjGEOM_MESH, f"Can only get mesh files for meshes, got type {geom.type}"
+
+    meshname = geom.meshname
+    mesh = spec.mesh(meshname)
+
+    mesh_path = Path(spec.modelfiledir) / spec.meshdir / mesh.file
+    return mesh_path
+
+
+def get_mesh_scale(spec: MjSpec, geom: MjsGeom) -> np.ndarray:
+    """Extracts the relevant scale parameters for a given geom in the MjSpec."""
+    assert geom.type == mujoco.mjtGeom.mjGEOM_MESH, (
+        f"Can only get mesh scale for mesh-type geoms, got type {geom.type}."
+    )
+
+    meshname = geom.meshname
+    mesh = spec.mesh(meshname)
+
+    return mesh.scale
 
 
 def is_trace_sensor(model: MjModel, sensorid: int) -> bool:

--- a/judo/visualizers/utils.py
+++ b/judo/visualizers/utils.py
@@ -64,7 +64,7 @@ def get_mesh_scale(spec: MjSpec, geom: MjsGeom) -> np.ndarray:
     meshname = geom.meshname
     mesh = spec.mesh(meshname)
 
-    return mesh.scale
+    return mesh.scale  # type: ignore
 
 
 def apply_mujoco_material(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ exclude=[
 ]
 
 [tool.ruff.lint]
+pydocstyle.convention = "google"
 select = [
     "ANN",  # annotations
     "N",  # naming conventions
@@ -156,9 +157,6 @@ ignore = [
     "PLR0915",  # Too many statements in function
     "PLR2004",  # magic numbers
 ]
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,6 @@ exclude=[
 ]
 
 [tool.ruff.lint]
-pydocstyle.convention = "google"
 select = [
     "ANN",  # annotations
     "N",  # naming conventions
@@ -157,6 +156,9 @@ ignore = [
     "PLR0915",  # Too many statements in function
     "PLR2004",  # magic numbers
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -17,12 +17,11 @@ from judo.visualizers.model import (
     add_segments,
     add_sphere,
     add_spline,
-    rgba_float_to_int,
-    rgba_int_to_float,
     set_mesh_color,
     set_segment_points,
     set_spline_positions,
 )
+from judo.visualizers.utils import rgba_float_to_int, rgba_int_to_float
 
 # Create a global ViserServer instance for use by the tests.
 viser_server = ViserServer()

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -27,12 +27,13 @@ from judo.visualizers.model import (
 # Create a global ViserServer instance for use by the tests.
 viser_server = ViserServer()
 model_path = str(MODEL_PATH / "xml/cylinder_push.xml")
-model = mujoco.MjModel.from_xml_path(model_path)
+spec = mujoco.MjSpec.from_file(model_path)
+model = spec.compile()
 
 
 def test_model_loading() -> None:
     """Test that the model loads correctly and creates bodies and geometries."""
-    viser_model = ViserMjModel(viser_server, model)
+    viser_model = ViserMjModel(viser_server, spec)
     assert viser_model is not None, "Failed to create ViserMjModel"
     assert len(viser_model._bodies) == model.nbody, "Incorrect number of bodies"
     assert len(viser_model._geoms) > 0, "No geometries created"
@@ -40,7 +41,7 @@ def test_model_loading() -> None:
 
 def test_set_data() -> None:
     """Test that setting data updates body positions and orientations."""
-    viser_model = ViserMjModel(viser_server, model)
+    viser_model = ViserMjModel(viser_server, spec)
     data = mujoco.MjData(model)
     data.qpos = np.random.randn(model.nq)
     data.qvel = np.random.randn(model.nv)
@@ -53,10 +54,10 @@ def test_set_data() -> None:
 
 def test_ground_plane() -> None:
     """Test that the ground plane can be toggled on and off."""
-    viser_model_with_plane = ViserMjModel(viser_server, model, show_ground_plane=True)
+    viser_model_with_plane = ViserMjModel(viser_server, spec, show_ground_plane=True)
     assert any("ground_plane" in geom.name for geom in viser_model_with_plane._geoms), "Ground plane not found"
 
-    viser_model_no_plane = ViserMjModel(viser_server, model, show_ground_plane=False)
+    viser_model_no_plane = ViserMjModel(viser_server, spec, show_ground_plane=False)
     assert all("ground_plane" not in geom.name for geom in viser_model_no_plane._geoms), "Unexpected ground plane"
 
 
@@ -251,7 +252,7 @@ def test_set_segment_points() -> None:
 
 def test_remove_traces() -> None:
     """Test that remove_traces clears the traces list."""
-    viser_model = ViserMjModel(viser_server, model)
+    viser_model = ViserMjModel(viser_server, spec)
     # Ensure _traces is defined.
     assert hasattr(viser_model, "_traces"), "Model does not have _traces attribute"
     # Remove the traces.
@@ -261,7 +262,7 @@ def test_remove_traces() -> None:
 
 def test_set_traces() -> None:
     """Test that set_traces correctly sets the traces and handles them."""
-    viser_model = ViserMjModel(viser_server, model)
+    viser_model = ViserMjModel(viser_server, spec)
     # Create a dummy trace array with shape (3, 2, 3)
     traces = np.random.rand(3, 2, 3)
     all_traces_rollout_size = 2
@@ -287,7 +288,7 @@ def test_set_traces() -> None:
 
 def test_remove() -> None:
     """Test that remove clears the traces and removes geometries."""
-    viser_model = ViserMjModel(viser_server, model)
+    viser_model = ViserMjModel(viser_server, spec)
     viser_model.remove()
     # Verify that traces are cleared.
     assert viser_model._traces == [], "remove did not clear _traces"


### PR DESCRIPTION
A medium-sized feature allowing us to apply MuJoCo textures to meshes. This was pretty rushed and likely needs more attention - the test coverage especially is not good, and I think there will be plenty of edge cases we should sort through more carefully (e.g., what happens if both the mesh has textures defined in mujoco and in the `.obj`?).

Still, the Franka does look much nicer now. 

Main changes: 
* Swapped the base `Task` to carry around an `MjSpec` (which has the asset filepaths inside it).
* Swapped the `ViserMjModel` to use this `MjSpec` to locate mesh assets and textures that will be better visualized in `viser`.
* Updated geom/body naming inside the `ViserMjModel`.
* Updated `ViserMjModel` unit tests to comply with the new interface. 