### PR TITLE
Update visualizer to strictly use the task's `sim_data` field

### DIFF
--- a/judo/app/simulation.py
+++ b/judo/app/simulation.py
@@ -62,9 +62,9 @@ class SimulationNode(DoraNode):
         """Step the simulation forward by one timestep."""
         if self.control is not None and not self.paused:
             try:
-                self.task.data.ctrl[:] = self.control(self.task.data.time)
+                self.task.sim_data.ctrl[:] = self.control(self.task.sim_data.time)
                 self.task.pre_sim_step()
-                mj_step(self.task.sim_model, self.task.data)
+                mj_step(self.task.sim_model, self.task.sim_data)
                 self.task.post_sim_step()
             except ValueError:
                 # we're switching tasks and the new task has a different number of actuators
@@ -92,13 +92,13 @@ class SimulationNode(DoraNode):
     def write_states(self) -> None:
         """Reads data from simulation and writes to output topic."""
         sim_state = MujocoState(
-            time=self.task.data.time,
-            qpos=self.task.data.qpos,  # type: ignore
-            qvel=self.task.data.qvel,  # type: ignore
-            xpos=self.task.data.xpos,  # type: ignore
-            xquat=self.task.data.xquat,  # type: ignore
-            mocap_pos=self.task.data.mocap_pos,  # type: ignore
-            mocap_quat=self.task.data.mocap_quat,  # type: ignore
+            time=self.task.sim_data.time,
+            qpos=self.task.sim_data.qpos,  # type: ignore
+            qvel=self.task.sim_data.qvel,  # type: ignore
+            xpos=self.task.sim_data.xpos,  # type: ignore
+            xquat=self.task.sim_data.xquat,  # type: ignore
+            mocap_pos=self.task.sim_data.mocap_pos,  # type: ignore
+            mocap_quat=self.task.sim_data.mocap_quat,  # type: ignore
             sim_metadata=self.task.get_sim_metadata(),
         )
         arr, metadata = to_arrow(sim_state)

--- a/judo/app/visualization.py
+++ b/judo/app/visualization.py
@@ -109,7 +109,7 @@ class VisualizationNode(DoraNode):
 
         task_cls, self.task_config_cls = task_entry
         self.task = task_cls()
-        self.data = mujoco.MjData(self.task.model)
+        self.data = mujoco.MjData(self.task.sim_model)
         self.viser_model = ViserMjModel(
             self.server,
             self.task.spec,

--- a/judo/tasks/base.py
+++ b/judo/tasks/base.py
@@ -30,6 +30,7 @@ class Task(ABC, Generic[ConfigT]):
         self.data = MjData(self.model)
         self.model_path = model_path
         self.sim_model = self.model if sim_model_path is None else MjModel.from_xml_path(str(sim_model_path))
+        self.sim_data = self.data if sim_model_path is None else MjData(self.sim_model)
 
     @property
     def time(self) -> float:

--- a/judo/tasks/cartpole.py
+++ b/judo/tasks/cartpole.py
@@ -75,6 +75,13 @@ class Cartpole(Task[CartpoleConfig]):
 
     def reset(self) -> None:
         """Resets the model to a default (random) state."""
-        self.data.qpos = np.array([1.0, np.pi]) + np.random.randn(2)
-        self.data.qvel = 1e-1 * np.random.randn(2)
+        qpos = np.array([1.0, np.pi]) + np.random.randn(2)
+        qvel = 1e-1 * np.random.randn(2)
+
+        self.data.qpos[:] = qpos
+        self.data.qvel[:] = qvel
+        self.sim_data.qpos[:] = qpos
+        self.sim_data.qvel[:] = qvel
+
         mujoco.mj_forward(self.model, self.data)
+        mujoco.mj_forward(self.sim_model, self.sim_data)

--- a/judo/tasks/cylinder_push.py
+++ b/judo/tasks/cylinder_push.py
@@ -93,7 +93,7 @@ class CylinderPush(Task[CylinderPushConfig]):
     def reset(self) -> None:
         """Resets the model to a default (random) state."""
         theta = 2 * np.pi * np.random.rand(2)
-        self.data.qpos = np.array(
+        qpos = np.array(
             [
                 np.cos(theta[0]),
                 np.sin(theta[0]),
@@ -101,5 +101,12 @@ class CylinderPush(Task[CylinderPushConfig]):
                 2 * np.sin(theta[1]),
             ]
         )
-        self.data.qvel = np.zeros(4)
+        qvel = np.zeros(4)
+
+        self.data.qpos[:] = qpos
+        self.data.qvel[:] = qvel
+        self.sim_data.qpos[:] = qpos
+        self.sim_data.qvel[:] = qvel
+
         mujoco.mj_forward(self.model, self.data)
+        mujoco.mj_forward(self.sim_model, self.sim_data)

--- a/judo/tasks/fr3_pick.py
+++ b/judo/tasks/fr3_pick.py
@@ -319,4 +319,9 @@ class FR3Pick(Task[FR3PickConfig]):
         self.data.qpos[:] = QPOS_HOME
         self.data.qvel[:] = 0.0
         self.data.ctrl[:] = self.reset_command
+        self.sim_data.qpos[:] = QPOS_HOME
+        self.sim_data.qvel[:] = 0.0
+        self.sim_data.ctrl[:] = self.reset_command
+
         mujoco.mj_forward(self.model, self.data)
+        mujoco.mj_forward(self.sim_model, self.sim_data)

--- a/judo/tasks/leap_cube.py
+++ b/judo/tasks/leap_cube.py
@@ -121,8 +121,13 @@ class LeapCube(Task[LeapCubeConfig]):
         self.data.qpos[:] = self.qpos_home
         self.data.qvel[:] = 0.0
         self.data.ctrl[:] = self.reset_command
+        self.sim_data.qpos[:] = self.qpos_home
+        self.sim_data.qvel[:] = 0.0
+        self.sim_data.ctrl[:] = self.reset_command
+
         self._update_goal_quat()
         mujoco.mj_forward(self.model, self.data)
+        mujoco.mj_forward(self.sim_model, self.sim_data)
 
     def get_sim_metadata(self) -> dict[str, Any]:
         """Returns the simulation's goal quat."""

--- a/judo/tasks/leap_cube.py
+++ b/judo/tasks/leap_cube.py
@@ -83,7 +83,7 @@ class LeapCube(Task[LeapCubeConfig]):
 
     def post_sim_step(self) -> None:
         """Checks if the cube has dropped and resets if so."""
-        has_dropped = self.data.qpos[2] < -0.3
+        has_dropped = self.sim_data.qpos[2] < -0.3
 
         # we reset here if the cube has dropped
         if has_dropped:
@@ -91,7 +91,7 @@ class LeapCube(Task[LeapCubeConfig]):
 
         # check whether goal quat needs to be updated
         goal_quat = self.goal_quat
-        q_diff = quat_diff(self.data.qpos[3:7], goal_quat)
+        q_diff = quat_diff(self.sim_data.qpos[3:7], goal_quat)
         sin_a_2 = np.linalg.norm(q_diff[1:])
         angle = 2 * np.arctan2(sin_a_2, q_diff[0])
         if angle > np.pi:
@@ -113,7 +113,7 @@ class LeapCube(Task[LeapCubeConfig]):
                 np.sqrt(uvw[0]) * np.cos(2 * np.pi * uvw[2]),
             ]
         )
-        self.data.mocap_quat[0] = goal_quat
+        self.sim_data.mocap_quat[0] = self.data.mocap_quat[0] = goal_quat
         self.goal_quat = goal_quat
 
     def reset(self) -> None:


### PR DESCRIPTION
This PR enforces a stronger separation between `task.data`, which holds the data for the control rollouts, and `task.sim_data`, which holds the data for the sim rollouts. It also updates the reset logic in all of the tasks to reset BOTH the sim and the controller.