### PR TITLE
Configure code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Run tests with coverage
         run: >
-          pixi run -e dev pytest --cov=judo --cov-branch
-          --cov-report=xml -rsx
+          pixi run -e dev pytest --cov=judo --cov-branch --cov-report=xml -rsx
 
       - name: Upload coverage reports to Codecov
         if: ${{ !cancelled() }}


### PR DESCRIPTION
This is tested on my fork. It uploaded the coverage to my fork's codecov page.
https://app.codecov.io/github/slecleach/judo/commit/047fc7bf144df542aca7a3c16d07559e1263b296

![image](https://github.com/user-attachments/assets/3d7eca11-1dcd-4d4b-b5e7-08ddc0c01e17)

This is covering the `judo` folder correctly:
![image](https://github.com/user-attachments/assets/93264bb7-a3ed-4673-b0cf-fb0534422412)

