### PR TITLE
Add a get function for sensors and joint positions + velocities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.0.05
 
 ## Added
-* Included functions for simpler model indexing
+* Included functions for simpler model indexing for sensors and joints
 
 # v0.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-# v0.0.5
+# v0.0.4
 
 ## Added
-* Included functions for simpler model indexing for sensors and joints
-
-# v0.0.4
+* Included functions for simpler model indexing for sensors and joints (@bhung, @alberthli, #76)
 
 ## Fixed
 * Fixed bug after spec changes where unnamed geoms were causing `judo` to crash (@alberthli, @pculbertson, #72)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.05
+# v0.0.5
 
 ## Added
 * Included functions for simpler model indexing for sensors and joints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.0.05
+
+## Added
+* Included functions for simpler model indexing
+
 # v0.0.4
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.0.4
 
 ## Added
-* Included functions for simpler model indexing for sensors and joints (@bhung, @alberthli, #76)
+* Included functions for simpler model indexing for sensors and joints (@bhung-bdai, @alberthli, #76)
 
 ## Fixed
 * Fixed bug after spec changes where unnamed geoms were causing `judo` to crash (@alberthli, @pculbertson, #72)

--- a/judo/__init__.py
+++ b/judo/__init__.py
@@ -4,3 +4,4 @@ from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).resolve().parent
 MODEL_PATH = PACKAGE_ROOT / "models"
+TEST_PATH = PACKAGE_ROOT.parent / "tests"

--- a/judo/tasks/base.py
+++ b/judo/tasks/base.py
@@ -145,7 +145,7 @@ class Task(ABC, Generic[ConfigT]):
         return self.model.sensor(sensor_name).adr[0]
 
     def get_joint_position_start_index(self, joint_name: str) -> int:
-        """Returns the starting index of a joint's position in the 'states' array given the sensor's name.
+        """Returns the starting index of a joint's position in the 'states' array given the joint's name.
 
         Args:
             joint_name: The name of the joint to get the starting index in the position of the state array.
@@ -153,7 +153,9 @@ class Task(ABC, Generic[ConfigT]):
         return self.model.jnt_qposadr[self.model.joint(joint_name).id]
 
     def get_joint_velocity_start_index(self, joint_name: str) -> int:
-        """Returns the starting index of a joint's velocity in the 'states' array given the sensor's name.
+        """Returns the starting index of a joint's velocity in the 'states' array given the joint's name.
+
+        NOTE: This is the index of the joint's velocity in the state array, which is after the position indices!
 
         Args:
             joint_name: The name of the joint to get the starting index in the state array of.

--- a/judo/tasks/base.py
+++ b/judo/tasks/base.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, List, TypeVar
 
 import mujoco
 import numpy as np
@@ -135,3 +135,27 @@ class Task(ABC, Generic[ConfigT]):
         This is used to provide an initial guess for the optimizer when optimizing the task before any iterations.
         """
         return np.zeros(self.nu)
+    
+    def get_sensor_start_index(self, sensor_name: str) -> int:
+        """Returns the starting index of a sensor in the 'sensors' array given the sensor's name.
+        
+        Args:
+            sensor_name: The name of the sensor to get the index of.
+        """
+        return self.model.sensor(sensor_name).adr[0]
+    
+    def get_joint_position_start_index(self, joint_name: str) -> int:
+        """Returns the starting index of a joint's position in the 'states' array given the sensor's name.
+        
+        Args:
+            joint_name: The name of the joint to get the starting index in the position of the state array.
+        """
+        return self.model.jnt_qposadr[self.model.joint(joint_name).id]
+    
+    def get_joint_velocity_start_index(self, joint_name: str) -> int:
+        """Returns the starting index of a joint's velocity in the 'states' array given the sensor's name.
+        
+        Args:
+            joint_name: The name of the joint to get the starting index in the state array of.
+        """
+        return self.model.nq + self.model.jnt_dofadr[self.model.joint(joint_name).id]

--- a/judo/tasks/base.py
+++ b/judo/tasks/base.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Generic, List, TypeVar
+from typing import Any, Generic, TypeVar
 
 import mujoco
 import numpy as np
@@ -135,26 +135,26 @@ class Task(ABC, Generic[ConfigT]):
         This is used to provide an initial guess for the optimizer when optimizing the task before any iterations.
         """
         return np.zeros(self.nu)
-    
+
     def get_sensor_start_index(self, sensor_name: str) -> int:
         """Returns the starting index of a sensor in the 'sensors' array given the sensor's name.
-        
+
         Args:
             sensor_name: The name of the sensor to get the index of.
         """
         return self.model.sensor(sensor_name).adr[0]
-    
+
     def get_joint_position_start_index(self, joint_name: str) -> int:
         """Returns the starting index of a joint's position in the 'states' array given the sensor's name.
-        
+
         Args:
             joint_name: The name of the joint to get the starting index in the position of the state array.
         """
         return self.model.jnt_qposadr[self.model.joint(joint_name).id]
-    
+
     def get_joint_velocity_start_index(self, joint_name: str) -> int:
         """Returns the starting index of a joint's velocity in the 'states' array given the sensor's name.
-        
+
         Args:
             joint_name: The name of the joint to get the starting index in the state array of.
         """

--- a/judo/tasks/fr3_pick.py
+++ b/judo/tasks/fr3_pick.py
@@ -108,42 +108,28 @@ class FR3Pick(Task[FR3PickConfig]):
         """Initializes the LEAP cube rotation task."""
         super().__init__(model_path, sim_model_path=sim_model_path)
         self.reset_command = np.array([0, 0, 0, -1.57079, 0, 1.57079, -0.7853, 0.0])
-
         # object indices
-        self.obj_pos_adr = self.model.jnt_qposadr[self.model.joint("object_joint").id]
+        self.obj_pos_adr = self.get_joint_position_start_index("object_joint")
         self.obj_pos_slice = slice(self.obj_pos_adr, self.obj_pos_adr + 3)
 
-        obj_vel_adr = self.model.nq + self.model.jnt_dofadr[self.model.joint("object_joint").id]
+        obj_vel_adr = self.get_joint_velocity_start_index("object_joint")
         self.obj_vel_slice = slice(obj_vel_adr, obj_vel_adr + 3)
 
         obj_angvel_adr = obj_vel_adr + 3
         self.obj_angvel_slice = slice(obj_angvel_adr, obj_angvel_adr + 3)
 
         # robot indices
-        arm_pos_adr = self.model.jnt_qposadr[self.model.joint("fr3_joint1").id]
+        arm_pos_adr = self.get_joint_position_start_index("fr3_joint1")
         self.arm_pos_slice = slice(arm_pos_adr, arm_pos_adr + 9)  # 7 + 2 dofs for the gripper
 
         # sensors
-        self.left_finger_obj_sensor = self.model.sensor("left_finger_obj")
-        self.left_finger_obj_adr = self.left_finger_obj_sensor.adr[0]
-
-        self.right_finger_obj_sensor = self.model.sensor("right_finger_obj")
-        self.right_finger_obj_adr = self.right_finger_obj_sensor.adr[0]
-
-        self.left_finger_table_sensor = self.model.sensor("left_finger_table")
-        self.left_finger_table_adr = self.left_finger_table_sensor.adr[0]
-
-        self.right_finger_table_sensor = self.model.sensor("right_finger_table")
-        self.right_finger_table_adr = self.right_finger_table_sensor.adr[0]
-
-        self.grasp_site_sensor = self.model.sensor("trace_grasp_site")
-        self.grasp_site_adr = self.grasp_site_sensor.adr[0]
-
-        self.obj_table_sensor = self.model.sensor("obj_table")
-        self.obj_table_adr = self.obj_table_sensor.adr[0]
-
-        self.ee_z_sensor = self.model.sensor("ee_z")
-        self.ee_z_adr = self.ee_z_sensor.adr[0]
+        self.left_finger_obj_adr = self.get_sensor_start_index("left_finger_obj")
+        self.right_finger_obj_adr = self.get_sensor_start_index("right_finger_obj")
+        self.left_finger_table_adr = self.get_sensor_start_index("left_finger_table")
+        self.right_finger_table_adr = self.get_sensor_start_index("right_finger_table")
+        self.grasp_site_adr = self.get_sensor_start_index("trace_grasp_site")
+        self.obj_table_adr = self.get_sensor_start_index("obj_table")
+        self.ee_z_adr = self.get_sensor_start_index("ee_z")
         self.ee_z_slice = slice(self.ee_z_adr, self.ee_z_adr + 3)
 
         # metadata that stores the current phase of the task

--- a/judo/tasks/fr3_pick.py
+++ b/judo/tasks/fr3_pick.py
@@ -108,6 +108,7 @@ class FR3Pick(Task[FR3PickConfig]):
         """Initializes the LEAP cube rotation task."""
         super().__init__(model_path, sim_model_path=sim_model_path)
         self.reset_command = np.array([0, 0, 0, -1.57079, 0, 1.57079, -0.7853, 0.0])
+
         # object indices
         self.obj_pos_adr = self.get_joint_position_start_index("object_joint")
         self.obj_pos_slice = slice(self.obj_pos_adr, self.obj_pos_adr + 3)

--- a/tests/test_tasks/test_indexing.py
+++ b/tests/test_tasks/test_indexing.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC. All rights reserved.
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from judo import TEST_PATH
+from judo.tasks.base import Task, TaskConfig
+
+
+@dataclass
+class TestConfig(TaskConfig):
+    """Test config."""
+
+
+class TestTask(Task[TestConfig]):
+    """Test task."""
+
+    def __init__(self, model_path: str = f"{TEST_PATH}/test_tasks/xml/test.xml") -> None:
+        """Initalizes a test task."""
+        super().__init__(model_path)
+        self.reset()
+
+    def reward(
+        self,
+        states: np.ndarray,
+        sensors: np.ndarray,
+        controls: np.ndarray,
+        config: TestConfig,
+        system_metadata: dict[str, Any] | None = None,
+    ) -> np.ndarray:
+        """Blank reward function for testing."""
+        return np.zeros(states.shape[0])
+
+
+def test_joint_position_indexing() -> None:
+    """Test to see if joint position index getter is working."""
+    test_task = TestTask()
+    assert test_task.get_joint_position_start_index("body_x") == 0
+    assert test_task.get_joint_position_start_index("body_y") == 1
+    assert test_task.get_joint_position_start_index("body_z") == 2
+
+
+def test_joint_velocity_indexing() -> None:
+    """Test to see if joint velocity index getter is working."""
+    test_task = TestTask()
+    assert test_task.get_joint_velocity_start_index("body_x") == 3
+    assert test_task.get_joint_velocity_start_index("body_y") == 4
+    assert test_task.get_joint_velocity_start_index("body_z") == 5
+
+
+def test_sensor_indexing() -> None:
+    """Test to see if sensor index getter is working."""
+    test_task = TestTask()
+    assert test_task.get_sensor_start_index("body_pos") == 0

--- a/tests/test_tasks/test_indexing.py
+++ b/tests/test_tasks/test_indexing.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2025 Robotics and AI Institute LLC. All rights reserved.
+
 from dataclasses import dataclass
 from typing import Any
 

--- a/tests/test_tasks/xml/test.xml
+++ b/tests/test_tasks/xml/test.xml
@@ -1,0 +1,27 @@
+<mujoco model="test">
+  <option timestep="0.02" />
+
+  <asset>
+    <texture name="blue_grid" type="2d" builtin="checker" rgb1=".02 .14 .44" rgb2=".27 .55 1" width="300" height="300" mark="edge" markrgb="1 1 1"/>
+    <material name="blue_grid" texture="blue_grid" texrepeat="1 1" texuniform="true" reflectance=".2"/>
+  </asset>
+
+  <worldbody>
+    <body>
+      <geom mass="0" name="floor" pos="0 0 -0.25" condim="3" size="10.0 10.0 0.10" rgba="0 1 1 1" type="box" material="blue_grid"/>
+    </body>
+
+    <body name="body" pos="0 0 0">
+      <joint name="body_x" damping="4" type="slide" axis="1 0 0" />
+      <joint name="body_y" damping="4" type="slide" axis="0 1 0" />
+      <joint name="body_z" damping="4" type="slide" axis="0 0 1" />
+      <geom name="body_geom" type="box" size="0.25 0.1 0.1" mass="0.1" rgba=".4 .4 .4 1" friction="0"/>
+      <site pos="0 0 0.1" name="body_site"/>
+    </body>
+  </worldbody>
+
+  <sensor>
+    <framepos name="body_pos" objtype="site" objname="body_site"/>
+  </sensor>
+
+</mujoco>


### PR DESCRIPTION
### Overview
Small and simple function addition which lets you automatically get a sensor index in the array given a name. This was included when a user came to ask me about this and was using the incorrect method to index into the sensor array.

### Summary
feat(task): add functions to get the start of the sensor index, joint position start index, and joint velocity start index
feat(test): include unit test folder for tasks and included unit test for the above functions on a test example

### Testing Done
- [x] Additional unit tests
- [x] Running the FR3 pick task and ensuring the behaviour is identical to the previous version.

### Code Qualty Guidelines
- [x] `pytest`
- [x] `pre-commit run --all-files` 
- [x] `pyright` (`pyright` errors result from mujoco)  